### PR TITLE
Include mime.types for Nginx

### DIFF
--- a/conf/nginx/base.conf.erb
+++ b/conf/nginx/base.conf.erb
@@ -16,5 +16,6 @@ http {
 
     index <%= ENV['INDEX_DOCUMENT'] %> index.html index.htm index.xhtml;
 
+    include mime.types;
     include site.conf;
 }


### PR DESCRIPTION
Without this all of my static files come out with type text/plain when served via Nginx.
