### PR TITLE
Fixes "cp: cannot create regular file `vendor/php/etc/conf.d': No such f...

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -289,7 +289,7 @@ for conf in $PHP_EXTRA_CONFIG; do
 done
 
 for include in $PHP_INCLUDES; do
-    cp "$BUILD_DIR/$include" "vendor/php/etc/conf.d"
+    cp "$BUILD_DIR/$include" "/app/vendor/php/etc/conf.d/"
 done
 
 # Detect PHP framework


### PR DESCRIPTION
If using the extra.heroku.php-includes option, this line was pointing to the wrong destination vendor path and threw a missing file or directory error.

```
"cp: cannot create regular file `vendor/php/etc/conf.d': No such file or directory"
```
