### PR TITLE
Fixes ls: cannot access vendor/nginx: No such file or directory in debug

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -273,8 +273,8 @@ if [ -f "$BUILD_DIR/composer.json" ] && package_newrelic_enabled; then
 fi
 
 if [ -n "$BUILDPACK_DEBUG" ]; then
-    ls -R vendor/nginx
-    ls -R vendor/php
+    ls -R /app/vendor/nginx
+    ls -R /app/vendor/php
 fi
 
 mkdir -p "conf"


### PR DESCRIPTION
Error prevented slug compilation if debug mode was turned on and threw the following error:

```
ls: cannot access vendor/nginx: No such file or directory
```
