### PR TITLE
Update newrelic.ini config to use heroku config vars

### DIFF
--- a/conf/php/newrelic.ini
+++ b/conf/php/newrelic.ini
@@ -1,4 +1,6 @@
 extension=newrelic.so
-newrelic.logfile=stdout
-newrelic.daemon.logfile=stdout
+newrelic.appname=${NEW_RELIC_APP_NAME}
+newrelic.license=${NEW_RELIC_LICENSE_KEY}
+newrelic.logfile=${NEW_RELIC_LOG}
+newrelic.daemon.logfile=${NEW_RELIC_LOG}
 newrelic.daemon.location=/app/vendor/newrelic/bin/newrelic-daemon


### PR DESCRIPTION
Using https://devcenter.heroku.com/articles/newrelic#node-js-agent-on-heroku as a guide, this seems like the thing to do.

Additional new relic should be put in code and should use the `extra.heroku.php-includes` option in `composer.json`
