### PR TITLE
H5BP server config best practices

### DIFF
--- a/conf/nginx/base.conf.erb
+++ b/conf/nginx/base.conf.erb
@@ -64,6 +64,9 @@ http {
         server_name localhost;
         listen <%= ENV['PORT'] %>;
 
+        #Specify a charset
+        charset utf-8;
+
         include site.conf;
 
         <% Shellwords.split(ENV['NGINX_INCLUDES'].to_s).each do |f| %>


### PR DESCRIPTION
Hi Christoph,

I've added some best practices from the [H5BP server configs](https://github.com/h5bp/server-configs-nginx), like a default charset, gzip encoding and default mime type. Maybe it's an idea to include these in the buildpack.

Cheers,

Robin
