### PR TITLE
Cakephp Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## What works?
 
 * Basic provisioning
-* NGINX Configuration for frameworks `silex` and `symfony2`
+* NGINX Configuration for frameworks `cakephp2`, `magento`, `silex`, `slim` and `symfony2`
 * Reading configuration from `composer.json`
 
 ## How to use it
@@ -56,9 +56,20 @@ app's root. And will install node dependencies like less for example.
 
 ## Frameworks
 
+### CakePHP
+
+Is used when the app requires the `pear-pear.cakephp.org/CakePHP` Pear package or when the
+`extra.heroku.framework` key is set to `cakephp2` in the `composer.json`.
+
+Options:
+
+* `index-document`: With Slim apps, this should be the file where `$Dispatcher->dispatch(new CakeRequest(), new CakeResponse());`
+  is called. All requests which don't match an existing file will be forwarded to
+  this document.
+
 ### Symfony 2
 
-Is detected when the app requires the `symfony/symfony` package or when the 
+Is detected when the app requires the `symfony/symfony` package or when the
 `extra.heroku.framework` key is set to `symfony2` in the `composer.json`.
 
 This framework preset doesn't need any configuration to work.
@@ -75,12 +86,24 @@ $ heroku labs:enable user-env-compile
 
 ### Silex
 
-Is used when the app requires the `silex/silex` package or when the 
+Is used when the app requires the `silex/silex` package or when the
 `extra.heroku.framework` key is set to `silex` in the `composer.json`.
 
 Options:
 
 * `index-document`: With Silex apps, this should be the file where `$app->run()`
+  is called. All requests which don't match an existing file will be forwarded to
+  this document.
+
+
+### Slim
+
+Is used when the app requires the `slim/slim` package or when the
+`extra.heroku.framework` key is set to `slim` in the `composer.json`.
+
+Options:
+
+* `index-document`: With Slim apps, this should be the file where `$app->run()`
   is called. All requests which don't match an existing file will be forwarded to
   this document.
 
@@ -133,8 +156,12 @@ be overriden!
 
 Available presets:
 
+* `cakephp2`
+* `magento`
 * `silex` (needs `document-root` and `index-document` set)
+* `slim`
 * `symfony2`
+
 
 Example:
 
@@ -209,7 +236,7 @@ framework provided config. File paths are treated relative to the app
 root.
 
 Example:
-    
+
     "nginx-includes": ["etc/nginx.conf"]
 
 #### compile

--- a/conf/nginx/cakephp2.conf.erb
+++ b/conf/nginx/cakephp2.conf.erb
@@ -1,0 +1,20 @@
+<% if ENV.has_key? "DOCUMENT_ROOT" and ENV['DOCUMENT_ROOT'].to_s != "" %>
+root /app/<%= ENV['DOCUMENT_ROOT'] %>;
+<% else %>
+root /app/webroot;
+<% end %>
+
+#all locations try other files first and go to our front controller if none of them exists
+location / {
+    try_files $uri $uri/ /<%= ENV['INDEX_DOCUMENT'] %>?$uri&$args;
+}
+
+location ~ \.php$ {
+    try_files $uri =404;
+    fastcgi_pass php;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_buffers 256 4k;
+    #uncomment when running via https
+    #fastcgi_param HTTPS on;
+}

--- a/frameworks/cakephp2
+++ b/frameworks/cakephp2
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+BUILD_DIR="$2"
+basedir="$( cd -P "$( dirname "$0" )" && pwd )"
+source $basedir/../bin/common.sh
+
+function requires_cakephp2() {
+    [ $(jq --raw-output '.require["pear-pear.cakephp.org/CakePHP"]' < "$BUILD_DIR/composer.json") != "null" ]
+}
+
+function sets_framework_cakephp2() {
+    [ $(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json") == "cakephp2" ]
+}
+
+case "$1" in
+    detect)
+        if [ ! -f "$BUILD_DIR/composer.json" ]; then
+            exit 1
+        fi
+
+        if requires_cakephp2 || sets_framework_cakephp2; then
+            echo "-----> Detected CakePHP2 App"
+            exit 0
+        else
+            exit 1
+        fi
+        ;;
+    compile)
+        echo "-----> Setting up CakePHP2 app"
+        cp "$basedir/../conf/nginx/cakephp2.conf.erb" "$BUILD_DIR/conf/site.conf.erb"
+        ;;
+esac


### PR DESCRIPTION
- Supports pear-based installation of CakePHP for autodetection - we don't currently have it in packagist because of reasons
- Uses the url rewriting configuration from [here](http://book.cakephp.org/2.0/en/installation/url-rewriting.html#pretty-urls-on-nginx)
- Added some docs on slim and stuff

Works here:
- http://cakephp-test.herokuapp.com/
- http://cakephp-test.herokuapp.com/pages/gnome

Seems legit? Refs FriendsOfCake/app-template#22
