### PR TITLE
Update nginx config to pass parameters to Slim

### DIFF
--- a/conf/nginx/slim.conf.erb
+++ b/conf/nginx/slim.conf.erb
@@ -1,7 +1,7 @@
 # Default configuration for non-framework apps
 root /app/<%= ENV['DOCUMENT_ROOT'] %>;
 
-try_files $uri /index.php;
+try_files $uri /index.php?$args;
 
 # this will only pass index.php to the fastcgi process which is generally safer but
 # assumes the whole site is run via Slim.


### PR DESCRIPTION
I have updated the nginx config for Slim as per: https://github.com/codeguy/Slim#nginx

With this change you can access the $_GET parameters via Slim

``` php
$app->get('/test', function () use ($app) {
    $allGetVars = $app->request->get();
    print_r($allGetVars);
});
```

A HTTP request to the following `/test?hello=123&world=321` will now output the expected result:

```
Array
(
    [hello] => 123
    [world] => 321
)
```

Without this change, the `/test` route would not even be triggered.
