### PR TITLE
Added a timezone by default

### DIFF
--- a/conf/php/php.ini
+++ b/conf/php/php.ini
@@ -3,6 +3,9 @@ display_errors=off
 log_errors=on
 error_reporting=E_ALL | E_STRICT
 
+; Required timezone
+date.timezone = UTC
+
 ; Security
 expose_php=off
 cgi.fix_pathinfo=0


### PR DESCRIPTION
All PHP date functions are triggering a warning if the timezone is not defined. The default config should allow having a working setup.

Overwriting the timezone is still possible by adding our own config, as it is appended at the end.
