### PR TITLE
Fixed the HTTPS support in NGinx

### DIFF
--- a/conf/nginx/base.conf.erb
+++ b/conf/nginx/base.conf.erb
@@ -20,9 +20,10 @@ http {
 
     client_max_body_size 100m;
     client_body_timeout 600s;
-    
-    # define the $https variable based on the forwarded proto as Nginx is not the SSL endpoint
-    map $http_x_forwarded_proto $https {
+
+    # define the $proxied_https variable based on the forwarded proto as Nginx is not the SSL endpoint
+    # The name $https cannot be used as the variable is already defined in Nginx core
+    map $http_x_forwarded_proto $proxied_https {
         default off;
         https on;
     }

--- a/conf/nginx/cakephp2.conf.erb
+++ b/conf/nginx/cakephp2.conf.erb
@@ -15,6 +15,5 @@ location ~ \.php$ {
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_buffers 256 4k;
-    #uncomment when running via https
-    #fastcgi_param HTTPS on;
+    fastcgi_param HTTPS $proxied_https;
 }

--- a/conf/nginx/default_site.conf.erb
+++ b/conf/nginx/default_site.conf.erb
@@ -6,4 +6,5 @@ location ~ \.php {
     fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
     fastcgi_pass php;
     fastcgi_buffers 256 4k;
+    fastcgi_param HTTPS $proxied_https;
 }

--- a/conf/nginx/magento.conf.erb
+++ b/conf/nginx/magento.conf.erb
@@ -2,6 +2,7 @@ root /app/<%= ENV['DOCUMENT_ROOT'] %>;
 
 include fastcgi_params;
 fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+fastcgi_param HTTPS $proxied_https;
 
 # http://alanstorm.com/magento_exception_handling_developer_mode
 # fastcgi_param MAGE_IS_DEVELOPER_MODE true;

--- a/conf/nginx/silex.conf.erb
+++ b/conf/nginx/silex.conf.erb
@@ -20,6 +20,5 @@ location @site {
     include fastcgi_params;
     fastcgi_param  SCRIPT_FILENAME $document_root/<%= ENV['INDEX_DOCUMENT'] %>;
     fastcgi_buffers 256 4k;
-    #uncomment when running via https
-    #fastcgi_param HTTPS on;
+    fastcgi_param HTTPS $proxied_https;
 }

--- a/conf/nginx/slim.conf.erb
+++ b/conf/nginx/slim.conf.erb
@@ -12,4 +12,5 @@ location /index.php {
     fastcgi_buffers 256 4k;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_pass php;
+    fastcgi_param HTTPS $proxied_https;
 }

--- a/conf/nginx/symfony2.conf.erb
+++ b/conf/nginx/symfony2.conf.erb
@@ -19,6 +19,7 @@ location ~ ^/(app|app_dev|config)\.php(/|$) {
     fastcgi_split_path_info ^(.+\.php)(/.*)$;
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param HTTPS $proxied_https;
 
     fastcgi_buffer_size 128k;
     fastcgi_buffers 4 256k;

--- a/conf/nginx/zf2.conf.erb
+++ b/conf/nginx/zf2.conf.erb
@@ -14,5 +14,6 @@ location /index.php {
     fastcgi_read_timeout 10s;
     fastcgi_buffers 256 4k;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param HTTPS $proxied_https;
     fastcgi_pass php;
 }


### PR DESCRIPTION
The $https variable is already defined in NGinx 1.1.11+ so it is not possible to overwrite it with a map. Using a different name is necessary.
My previous PR was actually wrong (I should have tried a deployment with it before submitting it)
