### PR TITLE
Remove the log file before initiating the fifo

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -38,6 +38,7 @@ init_log_plex_fifo() {
     echo "mkdir -p `dirname ${log_file}`"
   done
   for log_file in $*; do
+    echo "rm -f ${log_file}"
     echo "mkfifo ${log_file}"
   done
 }


### PR DESCRIPTION
The slug compilation could have created some of the log files already, for instance in the case of the Symfony2 cache warmup.
