### PR TITLE
Prevent empty "docker logs" output - Use cat instead of tail

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -57,3 +57,10 @@ tail_log_plex() {
     echo "tail -n 0 -qF --pid=\$\$ ${log_file} &"
   done
 }
+
+cat_log_plex() {
+  for log_file in $*; do
+    echo "cat ${log_file} &"
+  done
+}
+

--- a/bin/compile
+++ b/bin/compile
@@ -443,7 +443,7 @@ erb conf/nginx.conf.erb > /app/vendor/nginx/conf/nginx.conf
 erb conf/site.conf.erb > /app/vendor/nginx/conf/site.conf
 
 `init_log_plex_fifo ${LOG_FILES}`
-`tail_log_plex ${LOG_FILES} ${SYS_LOG_FILES}`
+`cat_log_plex ${LOG_FILES} ${SYS_LOG_FILES}`
 
 (
     exec php-fpm -p "/app/vendor/php"


### PR DESCRIPTION
Using cat instead of tail since tailing a named pipe has no effect on some systems