### PR TITLE
Removed nginx timeout directives

### DIFF
--- a/conf/nginx/slim.conf.erb
+++ b/conf/nginx/slim.conf.erb
@@ -7,8 +7,6 @@ try_files $uri /index.php?$args;
 # assumes the whole site is run via Slim.
 location /index.php {
     include fastcgi_params;
-    fastcgi_connect_timeout 3s;
-    fastcgi_read_timeout 10s;
     fastcgi_buffers 256 4k;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_pass php;

--- a/conf/nginx/yii.conf.erb
+++ b/conf/nginx/yii.conf.erb
@@ -16,8 +16,6 @@ location ~ ^/(protected|framework|themes/\w+/views) {
 
 location ~ \.php {
     include fastcgi_params;
-    fastcgi_connect_timeout 3s;
-    fastcgi_read_timeout 10s;
     fastcgi_buffers 256 4k;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_param HTTPS $proxied_https;

--- a/conf/nginx/zf2.conf.erb
+++ b/conf/nginx/zf2.conf.erb
@@ -10,8 +10,6 @@ try_files $uri /index.php?$args;
 # assumes the whole site is run via Zend 2.
 location /index.php {
     include fastcgi_params;
-    fastcgi_connect_timeout 3s;
-    fastcgi_read_timeout 10s;
     fastcgi_buffers 256 4k;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_param HTTPS $proxied_https;


### PR DESCRIPTION
Removed fastcgi timeout directives from .php location block so that these are inherited from general nginx configuration. Without this, it is not possible to override these timeout values in the nginx configuration files specified in "nginx-includes" in composer.json. 