### PR TITLE
instead of PIPO use stdout / stderr

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -276,7 +276,7 @@ PHP_INCLUDES=
 COMPILE_CMD=
 NGINX_INCLUDES=
 NEWRELIC_VERSION=4.4.5.35
-LOG_FILES=( "/app/vendor/nginx/logs/access.log" "/app/vendor/nginx/logs/error.log" "/app/vendor/php/var/log/error.log" )
+LOG_FILES=( )
 ADDITIONAL_INSTALLED_LIBS=()
 
 # Read config variables from composer.json if it exists
@@ -458,6 +458,9 @@ fi
 
 erb conf/nginx.conf.erb > /app/vendor/nginx/conf/nginx.conf
 erb conf/site.conf.erb > /app/vendor/nginx/conf/site.conf
+
+`init_log_plex_fifo ${LOG_FILES}`
+`tail_log_plex ${LOG_FILES} ${SYS_LOG_FILES}`
 
 (
     exec php-fpm -p "/app/vendor/php"

--- a/bin/compile
+++ b/bin/compile
@@ -459,9 +459,6 @@ fi
 erb conf/nginx.conf.erb > /app/vendor/nginx/conf/nginx.conf
 erb conf/site.conf.erb > /app/vendor/nginx/conf/site.conf
 
-`init_log_plex_fifo ${LOG_FILES}`
-`tail_log_plex ${LOG_FILES} ${SYS_LOG_FILES}`
-
 (
     exec php-fpm -p "/app/vendor/php"
     \$pmsgr < "php-fpm"

--- a/conf/nginx/base.conf.erb
+++ b/conf/nginx/base.conf.erb
@@ -15,8 +15,8 @@ http {
 
     keepalive_timeout  65;
 
-    error_log logs/error.log notice;
-    access_log logs/access.log;
+    error_log /dev/stdout notice;
+    access_log /dev/stderr;
 
     client_max_body_size 100m;
     client_body_timeout 600s;

--- a/conf/php/php-fpm.conf
+++ b/conf/php/php-fpm.conf
@@ -444,7 +444,7 @@ ping.path = /ping
 ; Note: on highloaded environement, this can cause some delay in the page
 ; process time (several ms).
 ; Default Value: no
-catch_workers_output = yes
+;catch_workers_output = yes
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit

--- a/conf/php/php-fpm.conf
+++ b/conf/php/php-fpm.conf
@@ -27,7 +27,7 @@
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; in a local file.
 ; Default Value: log/php-fpm.log
-error_log = var/log/error.log
+error_log = /dev/stderr
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities
@@ -444,7 +444,7 @@ ping.path = /ping
 ; Note: on highloaded environement, this can cause some delay in the page
 ; process time (several ms).
 ; Default Value: no
-;catch_workers_output = yes
+catch_workers_output = yes
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit


### PR DESCRIPTION
named FIFOs are very vulnerable for multiple for situations where multiple processes are using it. In case with "nginx" it does spawn children which open log files individually. Either this or something else causes log pipes to fail and I haven't find any way to fix them.

This request uses logging to stdout / stderr instead. php-fpm and nginx log out nicely and all this log is available from the docker now:

    docker logs -f <container>

Additionally I have enabled that worker output is also redirected through the error files.


This does raise a separate question - should there be a "production" and "development" deployment settings? 