### PR TITLE
Add the FTP extension

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -319,11 +319,11 @@ fi
 # Look for ".*" versions, match them against all available versions
 # and select the latest version which was found.
 if echo "$PHP_VERSION" | grep '\*' &>/dev/null; then
-    PHP_VERSION=$(echo "$AVAILABLE_PHP_VERSIONS" | grep "^$PHP_VERSION$" | sort -r | head -n1)
+    PHP_VERSION=$(echo "$AVAILABLE_PHP_VERSIONS" | grep "^$PHP_VERSION$" | sort -r -V | head -n1)
 fi
 
 if echo "$NGINX_VERSION" | grep '\*' &>/dev/null; then
-    NGINX_VERSION=$(echo "$AVAILABLE_NGINX_VERSIONS" | grep "^$NGINX_VERSION$" | sort -r | head -n1)
+    NGINX_VERSION=$(echo "$AVAILABLE_NGINX_VERSIONS" | grep "^$NGINX_VERSION$" | sort -r -V | head -n1)
 fi
 
 VENDORED_NGINX=/app/vendor/nginx

--- a/bin/compile
+++ b/bin/compile
@@ -99,22 +99,32 @@ function install_composer_deps() {
     cp "$CACHE_DIR/composer.phar" "$target/vendor/composer/bin/"
 
     local required_extensions=$(jq --raw-output '.require | keys | .[]' < "$BUILD_DIR/composer.json" | grep '^ext-' | sed 's/^ext-//')
+    local ext_dir=/app/vendor/php/lib/php/extensions/no-debug-non-zts-$(php_api_version)
     if [ -n "$required_extensions" ]; then
-        status "Bundling additional extensions $required_extensions"
+        status "Bundling additional extensions"
         for ext in $required_extensions; do
             echo "$ext" | indent
 
-            local ext_dependency=${PHP_EXT_DEPENDENCIES["$ext"]}
-            if [ -n "$ext_dependency" ]; then
-                local ext_dependency_target=${DEPENDENCY_TARGET["$ext_dependency"]}
-                if [ -n "$ext_dependency_target" ]; then
-                    fetch_package "$ext_dependency" "$ext_dependency_target" | indent
-                    ADDITIONAL_INSTALLED_LIBS+=("$ext_dependency_target")
-                fi
-            fi
+            local ext_ini="/app/vendor/php/etc/conf.d/$ext.ini"
 
-            # TODO: Find a better way to ignore extensions which were not found in S3
-            fetch_package "ext/$(php_api_version)/php-${ext}" "/app/vendor/php" 2>/dev/null || true | indent
+            if [ -f "$ext_ini" ]; then
+                echo "Already installed" | indent
+            elif [ -f "$ext_dir/$ext.so" ]; then
+                echo "Enabling bundled extension" | indent
+                echo "extension=$ext.so" > "$ext_ini"
+            else
+                local ext_dependency=${PHP_EXT_DEPENDENCIES["$ext"]}
+                if [ -n "$ext_dependency" ]; then
+                    local ext_dependency_target=${DEPENDENCY_TARGET["$ext_dependency"]}
+                    if [ -n "$ext_dependency_target" ]; then
+                        fetch_package "$ext_dependency" "$ext_dependency_target" | indent
+                        ADDITIONAL_INSTALLED_LIBS+=("$ext_dependency_target")
+                    fi
+                fi
+
+                # TODO: Find a better way to ignore extensions which were not found in S3
+                fetch_package "ext/$(php_api_version)/php-${ext}" "/app/vendor/php" 2>/dev/null || true | indent
+            fi
         done
     fi
 

--- a/support/package_ext
+++ b/support/package_ext
@@ -28,7 +28,7 @@ build_ext() {
 
     local php_version=$(\
         echo "$php_versions" \
-        | grep "^${php_series}.*$" | sort -r | head -n1)
+        | grep "^${php_series}.*$" | sort -r -V | head -n1)
 
     echo "-----> Building $ext_name for PHP module API version ${zend_api_version} using PHP ${php_version}"
 

--- a/support/package_php
+++ b/support/package_php
@@ -89,6 +89,7 @@ cd php-${php_version}
     --enable-bcmath \
     --with-readline \
     --with-mcrypt=/app/vendor/libmcrypt \
+    --enable-ftp=shared \
     --disable-debug
 make
 make install


### PR DESCRIPTION
The extension is built as shared so that it is loaded only for people needing it.
It is currently only available for the newly compiled PHP 5.5.24 version (I haven't recompiled older versions)

It also fixes the sorting of PHP versions to handle the comparison of ``5.5.9`` and ``5.5.24`` properly.