### PR TITLE
Update the amqp extension to 1.6.0 beta

### DIFF
--- a/conf/buildpack.conf
+++ b/conf/buildpack.conf
@@ -11,9 +11,9 @@ PHP_MODULE_API_VERSIONS["5.4"]="20100525"
 PHP_MODULE_API_VERSIONS["5.5"]="20121212"
 
 declare -A PHP_EXT_DEPENDENCIES
-PHP_EXT_DEPENDENCIES["amqp"]="librabbitmq-0.5.0"
+PHP_EXT_DEPENDENCIES["amqp"]="librabbitmq-0.5.2"
 PHP_EXT_DEPENDENCIES["ssh2"]="libssh2-1.4.3"
 
 declare -A DEPENDENCY_TARGET
-DEPENDENCY_TARGET["librabbitmq-0.5.0"]="/app/vendor/librabbitmq"
+DEPENDENCY_TARGET["librabbitmq-0.5.2"]="/app/vendor/librabbitmq"
 DEPENDENCY_TARGET["libssh2-1.4.3"]="/app/vendor/libssh2"

--- a/support/ext/amqp
+++ b/support/ext/amqp
@@ -3,8 +3,8 @@
 set -e
 set -o pipefail
 
-amqp_version=1.4.0
-librabbitmq_version=0.5.0
+amqp_version=1.6.0beta2
+librabbitmq_version=0.5.2
 
 mkdir -p /app/vendor/librabbitmq
 curl "http://${S3_BUCKET}.s3.amazonaws.com/package/librabbitmq-${librabbitmq_version}.tgz" | tar xzv -C /app/vendor/librabbitmq

--- a/support/package_librabbitmq
+++ b/support/package_librabbitmq
@@ -18,7 +18,7 @@ rm -rf $tempdir
 mkdir -p $tempdir
 cd $tempdir
 
-rabbitmq_version=0.5.0
+rabbitmq_version=0.5.2
 
 echo "-----> Downloading librabbitmq"
 


### PR DESCRIPTION
The 1.4 release does not work with the CloudAMQP addon due to a bug in the extension implementation.