### PR TITLE
Update the default PHP version to 5.5.24

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -269,7 +269,7 @@ export PATH="$HOME/bin:$PATH"
 curl "http://${S3_BUCKET}.s3.amazonaws.com/jq/jq" -L -s -o - > "$HOME/bin/jq"
 chmod +x "$HOME/bin/jq"
 
-DEFAULT_PHP="5.5.10"
+DEFAULT_PHP="5.5.24"
 DEFAULT_NGINX="1.4.4"
 
 AVAILABLE_PHP_VERSIONS=$(curl "http://${S3_BUCKET}.s3.amazonaws.com/manifest.php" 2> /dev/null)


### PR DESCRIPTION
PHP 5.5.24 is available now, so let's make it the default as it is much more secure than 5.5.10 (I plan to prepare the PHP 5.6 compilation soon, but it is not done yet)