### PR TITLE
Don't use the fifo for logs as it does not work on logplex

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -33,16 +33,6 @@ unique_array() {
   echo "$*" | tr ' ' '\n' | sort -u | tr '\n' ' '
 }
 
-init_log_plex_fifo() {
-  for log_file in $*; do
-    echo "mkdir -p `dirname ${log_file}`"
-  done
-  for log_file in $*; do
-    echo "rm -f ${log_file}"
-    echo "mkfifo ${log_file}"
-  done
-}
-
 init_log_plex() {
   for log_file in $*; do
     echo "mkdir -p `dirname ${log_file}`"

--- a/bin/compile
+++ b/bin/compile
@@ -459,7 +459,7 @@ fi
 erb conf/nginx.conf.erb > /app/vendor/nginx/conf/nginx.conf
 erb conf/site.conf.erb > /app/vendor/nginx/conf/site.conf
 
-`init_log_plex_fifo ${LOG_FILES}`
+`init_log_plex ${LOG_FILES}`
 `tail_log_plex ${LOG_FILES} ${SYS_LOG_FILES}`
 
 (


### PR DESCRIPTION
This is an alternative to #158 using real files rather that FIFO, matching the behavior of the official PHP buildpack.

Note that I'm actually running this code in production since 1 year, but I forgot to include it in the buildpack