### PR TITLE
Add support for the cedar-14 stack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,9 @@ The `master` branch should always contain production ready code. All
 features which are staged to go into the next release are found in the
 `development` branch.
 
-Releases are done by merging `development` to `master` and creating a
-tag on `master` which follows [Semantic Versioning][].
-
-[Semantic Versioning]: http://semver.org
-
 Features should always live in their own branch. Feature branches start
 with `feature/`, e.g. a name for your feature branch might be `feature/my-awesome-feature`.
-Feature branches should branch off `master`, and get merged to
+Feature branches should branch off `development`, and get merged to
 `development` once they are reviewed.
 
 * * *
@@ -22,6 +17,20 @@ Please submit pull requests to the `development` branch. The
 `development` branch is used to make new releases of this buildpack,
 which are available to _all_ users.
 
+## Releasing new versions
+
+Releases are done by merging `development` to `master` and creating a
+tag on `master` which follows [Semantic Versioning][].
+
+When merging `development` into `master`, the compiled assets for
+master must be updated:
+
+```bash
+$ s3cmd cp --recursive --acl-public s3://chh-heroku-buildpack-php/develop s3://chh-heroku-buildpack-php/master
+```
+
+[Semantic Versioning]: http://semver.org
+
 ## Hacking
 
 ### Setup
@@ -29,7 +38,12 @@ which are available to _all_ users.
 You need the following tools to hack on this project:
 
 * An Amazon S3 bucket
-* An heroku application using the cedar-10 stack (the buildpack is not compatible with the cedar-14 stack) to run the compilation
+* An heroku application to run the compilation
+
+An heroku application is needed for each of the stacks for which you
+want to compile dependencies. An environment variable `TARGET_STACK`
+needs to be set with the stack name being used (``cedar`` for the
+cedar-10 stack, or ``cedar-14`` for the cedar-14 stack)
 
 Setup an S3 Bucket in Amazon. Then note the name of your bucket
 and set it as `S3_BUCKET` in `conf/buildpack.conf`.
@@ -43,9 +57,9 @@ You should then configure the application to be ready to be used for packaging:
 $ heroku git:remote -a buildpack-packaging
 
 # configure the AWS credentials
-$ heroku config:set AWS_ACCESS_KEY='<access key>' AWS_SECRET_KEY='<secret key>'
+$ heroku config:set AWS_ACCESS_KEY='<access key>' AWS_SECRET_KEY='<secret key>' TARGET_STACK='<stack name>'
 
-# deploy the buildpack code to heroku (the development branch here
+# deploy the buildpack code to heroku (the development branch here)
 $ git push heroku development:master
 ```
 

--- a/bin/compile
+++ b/bin/compile
@@ -32,8 +32,8 @@ function fetch_package() {
 
     mkdir -p "$location"
 
-    local checksum_url="http://${S3_BUCKET}.s3.amazonaws.com/package/${package}.md5"
-    local package_url="http://${S3_BUCKET}.s3.amazonaws.com/package/${package}.tgz"
+    local checksum_url="${S3_URL}/package/${package}.md5"
+    local package_url="${S3_URL}/package/${package}.tgz"
     local checksum=$(curl "$checksum_url" 2> /dev/null)
     local cache_checksum=
 
@@ -86,12 +86,12 @@ function install_composer_deps() {
     mkdir -p $COMPOSER_CACHE_DIR
     mkdir -p "$target/vendor/composer/bin"
 
-    local checksum=$(curl --silent "http://${S3_BUCKET}.s3.amazonaws.com/composer/composer.phar.md5")
+    local checksum=$(curl --silent "https://${S3_BUCKET}.s3.amazonaws.com/composer/composer.phar.md5")
 
     status "Vendoring Composer"
     if [ ! -f "$CACHE_DIR/composer.phar.md5" ] || [ "$(cat $CACHE_DIR/composer.phar.md5)" != "$checksum" ]; then
         echo "Updating Composer" | indent
-        curl --silent "http://${S3_BUCKET}.s3.amazonaws.com/composer/composer.phar" > "$CACHE_DIR/composer.phar" | indent
+        curl --silent "https://${S3_BUCKET}.s3.amazonaws.com/composer/composer.phar" > "$CACHE_DIR/composer.phar" | indent
         chmod a+x "$CACHE_DIR/composer.phar"
         echo "$checksum" > $CACHE_DIR/composer.phar.md5
     fi
@@ -265,16 +265,30 @@ function package_newrelic_enabled() {
 
 export_env_dir "$3"
 
+STACK=${STACK:-cedar} # Anvil has none
+
+BUILDPACK_URL=${BUILDPACK_URL:-} # Anvil has none
+BUILDPACK_BRANCH=$(expr "$BUILDPACK_URL" : '^.*/heroku-buildpack-php#\(..*\)$' || expr "$BUILDPACK_URL" : '^.*/heroku-buildpack-php\.git#\(..*\)$' || true) # POSIX expr doesn't understand ".+" or "(\.git)?"
+BUILDPACK_BRANCH=${BUILDPACK_BRANCH:-master}
+
+if [[ "$BUILDPACK_BRANCH" != v* && "$BUILDPACK_BRANCH" != "master" ]]; then
+    BUILDPACK_VERSION="develop"
+else
+    BUILDPACK_VERSION="master"
+fi
+
+S3_URL="https://${S3_BUCKET}.s3.amazonaws.com/${BUILDPACK_VERSION}/${STACK}"
+
 # Download jq binary for JSON processing
 export PATH="$HOME/bin:$PATH"
-curl "http://${S3_BUCKET}.s3.amazonaws.com/jq/jq" -L -s -o - > "$HOME/bin/jq"
+curl "https://${S3_BUCKET}.s3.amazonaws.com/jq/jq" -L -s -o - > "$HOME/bin/jq"
 chmod +x "$HOME/bin/jq"
 
 DEFAULT_PHP="5.5.24"
 DEFAULT_NGINX="1.4.4"
 
-AVAILABLE_PHP_VERSIONS=$(curl "http://${S3_BUCKET}.s3.amazonaws.com/manifest.php" 2> /dev/null)
-AVAILABLE_NGINX_VERSIONS=$(curl "http://${S3_BUCKET}.s3.amazonaws.com/manifest.nginx" 2> /dev/null)
+AVAILABLE_PHP_VERSIONS=$(curl "${S3_URL}/manifest.php" 2> /dev/null)
+AVAILABLE_NGINX_VERSIONS=$(curl "${S3_URL}/manifest.nginx" 2> /dev/null)
 
 MCRYPT_VERSION="2.5.8"
 PHP_VERSION="default"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-https://github.com/s3tools/s3cmd/archive/v1.5.2.zip
+https://github.com/s3tools/s3cmd/archive/v1.6.0.zip

--- a/support/ext/amqp
+++ b/support/ext/amqp
@@ -7,7 +7,7 @@ amqp_version=1.6.0beta2
 librabbitmq_version=0.5.2
 
 mkdir -p /app/vendor/librabbitmq
-curl "http://${S3_BUCKET}.s3.amazonaws.com/package/librabbitmq-${librabbitmq_version}.tgz" | tar xzv -C /app/vendor/librabbitmq
+curl "${S3_URL}/package/librabbitmq-${librabbitmq_version}.tgz" | tar xzv -C /app/vendor/librabbitmq
 
 curl -L "http://pecl.php.net/get/amqp-${amqp_version}.tgz" \
     | tar xzv

--- a/support/ext/amqp
+++ b/support/ext/amqp
@@ -20,4 +20,4 @@ cd amqp-${amqp_version}
 
 make
 cp modules/amqp.so "$EXT_DIR/amqp.so"
-echo "extension=amqp.so" > "$PREFIX/etc/conf.d/amqp.ini"
+echo "extension=amqp.so" > "$CONF_DIR/amqp.ini"

--- a/support/ext/apcu
+++ b/support/ext/apcu
@@ -14,4 +14,4 @@ cd apcu-${apcu_version}
 
 make
 cp modules/apcu.so "$EXT_DIR/apcu.so"
-echo "extension=apcu.so" > "$PREFIX/etc/conf.d/apcu.ini"
+echo "extension=apcu.so" > "$CONF_DIR/apcu.ini"

--- a/support/ext/igbinary
+++ b/support/ext/igbinary
@@ -15,4 +15,4 @@ cd "igbinary-${igbinary_version}"
 
 make
 cp modules/igbinary.so "$EXT_DIR/igbinary.so"
-echo "extension=igbinary.so" > "$PREFIX/etc/conf.d/igbinary.ini"
+echo "extension=igbinary.so" > "$CONF_DIR/igbinary.ini"

--- a/support/ext/imagick
+++ b/support/ext/imagick
@@ -14,4 +14,4 @@ cd imagick-${imagick_version}
 
 make
 cp modules/imagick.so "$EXT_DIR/imagick.so"
-echo "extension=imagick.so" > "$PREFIX/etc/conf.d/imagick.ini"
+echo "extension=imagick.so" > "$CONF_DIR/imagick.ini"

--- a/support/ext/libevent
+++ b/support/ext/libevent
@@ -14,4 +14,4 @@ cd libevent-${libevent_version}
 
 make
 cp modules/libevent.so "$EXT_DIR/libevent.so"
-echo "extension=libevent.so" > "$PREFIX/etc/conf.d/libevent.ini"
+echo "extension=libevent.so" > "$CONF_DIR/libevent.ini"

--- a/support/ext/memcache
+++ b/support/ext/memcache
@@ -14,4 +14,4 @@ cd pecl-caching-memcache-${php_memcache_version}
 
 make
 cp modules/memcache.so "$EXT_DIR/memcache.so"
-echo "extension=memcache.so" > "$PREFIX/etc/conf.d/memcache.ini"
+echo "extension=memcache.so" > "$CONF_DIR/memcache.ini"

--- a/support/ext/memcached
+++ b/support/ext/memcached
@@ -9,7 +9,7 @@ curl -L "https://github.com/andreiz/php-memcached/archive/${php_memcached_versio
     | tar xzv
 
 mkdir -p /app/vendor/libmemcached
-curl "https://s3-eu-west-1.amazonaws.com/chh-heroku-buildpack-php/package/libmemcached-1.0.17.tgz" \
+curl "${S3_URL}/package/libmemcached-1.0.17.tgz" \
     | tar xzv -C /app/vendor/libmemcached
 
 cd php-memcached-${php_memcached_version}

--- a/support/ext/memcached
+++ b/support/ext/memcached
@@ -20,4 +20,4 @@ cd php-memcached-${php_memcached_version}
 
 make
 cp modules/memcached.so "$EXT_DIR/memcached.so"
-echo "extension=memcached.so" > "$PREFIX/etc/conf.d/memcached.ini"
+echo "extension=memcached.so" > "$CONF_DIR/memcached.ini"

--- a/support/ext/mongo
+++ b/support/ext/mongo
@@ -15,4 +15,4 @@ cd mongo-php-driver-${mongo_version}
 
 make
 cp modules/mongo.so "$EXT_DIR/mongo.so"
-echo "extension=mongo.so" > "$PREFIX/etc/conf.d/mongo.ini"
+echo "extension=mongo.so" > "$CONF_DIR/mongo.ini"

--- a/support/ext/redis
+++ b/support/ext/redis
@@ -15,4 +15,4 @@ cd phpredis-${phpredis_version}
 
 make
 cp modules/redis.so "$EXT_DIR/redis.so"
-echo "extension=redis.so" > "$PREFIX/etc/conf.d/redis.ini"
+echo "extension=redis.so" > "$CONF_DIR/redis.ini"

--- a/support/ext/ssh2
+++ b/support/ext/ssh2
@@ -19,4 +19,4 @@ cd ssh2-${ssh2_version}
 
 make
 cp modules/ssh2.so "$EXT_DIR/ssh2.so"
-echo "extension=ssh2.so" > "$PREFIX/etc/conf.d/ssh2.ini"
+echo "extension=ssh2.so" > "$CONF_DIR/ssh2.ini"

--- a/support/ext/ssh2
+++ b/support/ext/ssh2
@@ -7,7 +7,7 @@ ssh2_version=0.12
 libssh2_version=1.4.3
 
 mkdir -p /app/vendor/libssh2
-curl "http://${S3_BUCKET}.s3.amazonaws.com/package/libssh2-${libssh2_version=1.4.3}.tgz" | tar xzv -C /app/vendor/libssh2
+curl "${S3_URL}/package/libssh2-${libssh2_version=1.4.3}.tgz" | tar xzv -C /app/vendor/libssh2
 
 curl -L "http://pecl.php.net/get/ssh2-${ssh2_version}.tgz" \
     | tar xzv

--- a/support/ext/sundown
+++ b/support/ext/sundown
@@ -14,4 +14,4 @@ cd sundown-${sundown_version}
 
 make
 cp modules/sundown.so "$EXT_DIR/sundown.so"
-echo "extension=sundown.so" > "$PREFIX/etc/conf.d/sundown.ini"
+echo "extension=sundown.so" > "$CONF_DIR/sundown.ini"

--- a/support/manifest
+++ b/support/manifest
@@ -29,6 +29,11 @@ if [ -z "$S3_BUCKET" ]; then
     exit 1
 fi
 
+if [ -z "$TARGET_STACK" ]; then
+    echo "TARGET_STACK must be set" >&2
+    exit 1
+fi
+
 # make a temp directory
 tempdir="$( mktemp -t php_XXXX )"
 rm -rf $tempdir
@@ -37,9 +42,9 @@ pushd $tempdir > /dev/null
 
 echo "-----> Manifest for $manifest_type"
 
-s3cmd ls "s3://$S3_BUCKET/package/" \
+s3cmd ls "s3://$S3_BUCKET/develop/$TARGET_STACK/package/" \
     | awk '{ print $4 }' \
-    | sed "s/^s3:\/\/$S3_BUCKET\/package\///" \
+    | sed "s/^s3:\/\/$S3_BUCKET\/develop\/$TARGET_STACK\/package\///" \
     | grep "\.tgz$" \
     | grep "${manifest_type}" \
     | grep -v -e ".md5" \
@@ -55,5 +60,5 @@ echo
 echo "-----> Uploading manifest for ${manifest_type} to S3"
 
 s3cmd put --acl-public --mime-type="text/plain" \
-    manifest.${manifest_type} "s3://$S3_BUCKET" \
+    manifest.${manifest_type} "s3://$S3_BUCKET/develop/$TARGET_STACK/" \
     | fold -w 70 | indent

--- a/support/package-checksum
+++ b/support/package-checksum
@@ -11,6 +11,11 @@ if [ -z "$S3_BUCKET" ]; then
     exit $E_S3_BUCKET_MISSING
 fi
 
+if [ -z "$TARGET_STACK" ]; then
+    echo "TARGET_STACK must be set" >&2
+    exit 1
+fi
+
 package="$1"
 
 tempdir="$( mktemp -t s3_XXXX )"
@@ -20,7 +25,7 @@ cd $tempdir
 
 echo "-----> Creating checksum for ${package}"
 
-s3cmd get "s3://$S3_BUCKET/package/${package}.tgz" "${package}.tgz"
+s3cmd get "s3://$S3_BUCKET/develop/$TARGET_STACK/package/${package}.tgz" "${package}.tgz"
 if hash md5sum 2>/dev/null; then
     md5sum "${package}.tgz" > "${package}.md5"
 else
@@ -28,4 +33,4 @@ else
 fi
 s3cmd put \
     --verbose --acl-public \
-    "${package}.md5" "s3://$S3_BUCKET/package/${package}.md5"
+    "${package}.md5" "s3://$S3_BUCKET/develop/$TARGET_STACK/package/${package}.md5"

--- a/support/package_ext
+++ b/support/package_ext
@@ -40,18 +40,22 @@ build_ext() {
 
     cd "$tempdir"
 
+    # clean any previous state to be sure we don't include unwanted things
+    rm -rf /app/vendor/php
+
     mkdir -p /app/vendor/php
-    mkdir -p "/tmp/out/$ext_dir"
-    mkdir -p "/tmp/out/etc/conf.d"
+    mkdir -p "/$tempdir/out/$ext_dir"
+    mkdir -p "/$tempdir/out/etc/conf.d"
+
     curl -L "$php_package" | tar -xzv -C /app/vendor/php
 
     echo "-----> Compiling the extension"
 
-    PREFIX="/tmp/out" EXT_DIR="/tmp/out/$ext_dir" S3_URL="$s3_url" ./build.sh
+    CONF_DIR="/$tempdir/out/etc/conf.d" EXT_DIR="/$tempdir/out/$ext_dir" S3_URL="$s3_url" ./build.sh
 
     echo "-----> Building the archive"
 
-    pushd /tmp/out/
+    pushd "/$tempdir/out/"
 
     tar czf "$tempdir/php-${ext_name}.tgz" *
 

--- a/support/package_ext
+++ b/support/package_ext
@@ -33,7 +33,8 @@ build_ext() {
     echo "-----> Building $ext_name for PHP module API version ${zend_api_version} using PHP ${php_version}"
 
     local ext_dir="lib/php/extensions/no-debug-non-zts-${zend_api_version}"
-    local php_package="http://${S3_BUCKET}.s3.amazonaws.com/package/php-${php_version}.tgz"
+    local s3_url="https://${S3_BUCKET}.s3.amazonaws.com/develop/${TARGET_STACK}"
+    local php_package="${s3_url}/package/php-${php_version}.tgz"
 
     cp "$basedir/ext/${ext_name}" "$tempdir/build.sh"
 
@@ -46,7 +47,7 @@ build_ext() {
 
     echo "-----> Compiling the extension"
 
-    PREFIX="/tmp/out" EXT_DIR="/tmp/out/$ext_dir" S3_BUCKET="$S3_BUCKET" ./build.sh
+    PREFIX="/tmp/out" EXT_DIR="/tmp/out/$ext_dir" S3_URL="$s3_url" ./build.sh
 
     echo "-----> Building the archive"
 
@@ -59,7 +60,7 @@ build_ext() {
     s3cmd put --verbose \
         --acl-public \
         "$tempdir/php-${ext_name}.tgz" \
-        "s3://$S3_BUCKET/package/ext/${zend_api_version}/php-${ext_name}.tgz"
+        "s3://$S3_BUCKET/develop/$TARGET_STACK/package/ext/${zend_api_version}/php-${ext_name}.tgz"
 
     "$basedir/package-checksum" "ext/${zend_api_version}/php-${ext_name}"
 }
@@ -69,7 +70,17 @@ source "$basedir/../conf/buildpack.conf"
 
 export PATH=${basedir}/../vendor/bin:$PATH
 
-php_versions=$(curl --silent "http://${S3_BUCKET}.s3.amazonaws.com/manifest.php")
+if [ -z "$S3_BUCKET" ]; then
+    echo "Must set S3_BUCKET environment variable" >&2
+    exit 1
+fi
+
+if [ -z "$TARGET_STACK" ]; then
+    echo "TARGET_STACK must be set" >&2
+    exit 1
+fi
+
+php_versions=$(curl --silent "https://${S3_BUCKET}.s3.amazonaws.com/develop/${TARGET_STACK}/manifest.php")
 
 ext_name="$1"
 shift

--- a/support/package_icu
+++ b/support/package_icu
@@ -15,6 +15,11 @@ if [ -z "$S3_BUCKET" ]; then
     exit 1
 fi
 
+if [ -z "$TARGET_STACK" ]; then
+    echo "TARGET_STACK must be set" >&2
+    exit 1
+fi
+
 tempdir="$( mktemp -t libicu_XXXX )"
 rm -rf $tempdir
 mkdir -p $tempdir
@@ -43,6 +48,6 @@ popd
 s3cmd put \
     --verbose --acl-public \
     "$tempdir/libicu-51.tgz" \
-    "s3://$S3_BUCKET/package/libicu-51.tgz"
+    "s3://$S3_BUCKET/develop/$TARGET_STACK/package/libicu-51.tgz"
 
 "$basedir/package-checksum" "libicu-51"

--- a/support/package_icu
+++ b/support/package_icu
@@ -25,6 +25,8 @@ rm -rf $tempdir
 mkdir -p $tempdir
 cd $tempdir
 
+rm -rf /app/vendor/libicu
+
 echo "-----> Downloading libicu"
 
 curl -L "$download_url" | tar xzv

--- a/support/package_libmcrypt
+++ b/support/package_libmcrypt
@@ -30,6 +30,8 @@ rm -rf $tempdir
 mkdir -p $tempdir
 cd $tempdir
 
+rm -rf /app/vendor/libmcrypt
+
 echo "-----> Downloading libmcrypt ${mcrypt_version}"
 curl -L "http://sourceforge.net/projects/mcrypt/files/Libmcrypt/${mcrypt_version}/libmcrypt-${mcrypt_version}.tar.gz/download" \
     | tar xzv

--- a/support/package_libmcrypt
+++ b/support/package_libmcrypt
@@ -20,6 +20,11 @@ if [ -z "$S3_BUCKET" ]; then
     exit 1
 fi
 
+if [ -z "$TARGET_STACK" ]; then
+    echo "TARGET_STACK must be set" >&2
+    exit 1
+fi
+
 tempdir="$( mktemp -t libmcrypt_XXXX )"
 rm -rf $tempdir
 mkdir -p $tempdir
@@ -48,6 +53,6 @@ popd
 s3cmd put \
     --verbose --acl-public \
     "$tempdir/libmcrypt-${mcrypt_version}.tgz" \
-    "s3://$S3_BUCKET/package/libmcrypt-${mcrypt_version}.tgz"
+    "s3://$S3_BUCKET/develop/$TARGET_STACK/package/libmcrypt-${mcrypt_version}.tgz"
 
 "$basedir/package-checksum" "libmcrypt-${mcrypt_version}"

--- a/support/package_libmemcached
+++ b/support/package_libmemcached
@@ -13,6 +13,11 @@ if [ -z "$S3_BUCKET" ]; then
     exit 1
 fi
 
+if [ -z "$TARGET_STACK" ]; then
+    echo "TARGET_STACK must be set" >&2
+    exit 1
+fi
+
 tempdir="$( mktemp -t libmemcached_XXXX )"
 rm -rf $tempdir
 mkdir -p $tempdir
@@ -41,7 +46,7 @@ tar czf "$tempdir/libmemcached-${memcached_version}.tgz" *
 
 popd
 
-s3_path=s3://$S3_BUCKET/package/libmemcached-${memcached_version}.tgz
+s3_path=s3://$S3_BUCKET/develop/$TARGET_STACK/package/libmemcached-${memcached_version}.tgz
 
 echo "-----> Uploading package to ${s3_path}"
 

--- a/support/package_libmemcached
+++ b/support/package_libmemcached
@@ -23,6 +23,8 @@ rm -rf $tempdir
 mkdir -p $tempdir
 cd $tempdir
 
+rm -rf /app/vendor/libmemcached
+
 memcached_version=1.0.17
 
 echo "-----> Downloading libmemcached"

--- a/support/package_librabbitmq
+++ b/support/package_librabbitmq
@@ -13,6 +13,11 @@ if [ -z "$S3_BUCKET" ]; then
     exit 1
 fi
 
+if [ -z "$TARGET_STACK" ]; then
+    echo "TARGET_STACK must be set" >&2
+    exit 1
+fi
+
 tempdir="$( mktemp -t librabbitmq_XXXX )"
 rm -rf $tempdir
 mkdir -p $tempdir
@@ -46,6 +51,6 @@ popd
 s3cmd put \
     --verbose --acl-public \
     "$tempdir/librabbitmq-${rabbitmq_version}.tgz" \
-    "s3://$S3_BUCKET/package/librabbitmq-${rabbitmq_version}.tgz"
+    "s3://$S3_BUCKET/develop/$TARGET_STACK/package/librabbitmq-${rabbitmq_version}.tgz"
 
 "$basedir/package-checksum" "librabbitmq-${rabbitmq_version}"

--- a/support/package_librabbitmq
+++ b/support/package_librabbitmq
@@ -23,6 +23,8 @@ rm -rf $tempdir
 mkdir -p $tempdir
 cd $tempdir
 
+rm -rf /app/vendor/librabbitmq
+
 rabbitmq_version=0.5.2
 
 echo "-----> Downloading librabbitmq"

--- a/support/package_libssh2
+++ b/support/package_libssh2
@@ -13,6 +13,11 @@ if [ -z "$S3_BUCKET" ]; then
     exit 1
 fi
 
+if [ -z "$TARGET_STACK" ]; then
+    echo "TARGET_STACK must be set" >&2
+    exit 1
+fi
+
 tempdir="$( mktemp -t libssh2_XXXX )"
 rm -rf $tempdir
 mkdir -p $tempdir
@@ -44,6 +49,6 @@ popd
 s3cmd put \
     --verbose --acl-public \
     "$tempdir/libssh2-${libssh2_version}.tgz" \
-    "s3://$S3_BUCKET/package/libssh2-${libssh2_version}.tgz"
+    "s3://$S3_BUCKET/develop/$TARGET_STACK/package/libssh2-${libssh2_version}.tgz"
 
 "$basedir/package-checksum" "libssh2-${libssh2_version}"

--- a/support/package_libssh2
+++ b/support/package_libssh2
@@ -23,6 +23,8 @@ rm -rf $tempdir
 mkdir -p $tempdir
 cd $tempdir
 
+rm -rf /app/vendor/libssh2
+
 libssh2_version=1.4.3
 
 echo "-----> Downloading libssh2"

--- a/support/package_nginx
+++ b/support/package_nginx
@@ -13,6 +13,16 @@ source "$basedir/../conf/buildpack.conf"
 
 export PATH=${basedir}/../vendor/bin:$PATH
 
+if [ -z "$S3_BUCKET" ]; then
+    echo "Must set S3_BUCKET environment variable" >&2
+    exit 1
+fi
+
+if [ -z "$TARGET_STACK" ]; then
+    echo "TARGET_STACK must be set" >&2
+    exit 1
+fi
+
 if [ -z "$nginx_version" ]; then
     echo "Usage: $0 <version>" >&2
     exit $E_ARG_MISSING
@@ -41,7 +51,7 @@ tar -xzvf "pcre-${pcre_version}.tar.gz"
 
 echo "-----> Downloading dependency zlib ${zlib_version}"
 
-curl -LO "http://${S3_BUCKET}.s3.amazonaws.com/zlib/zlib-${zlib_version}.tar.gz"
+curl -LO "https://${S3_BUCKET}.s3.amazonaws.com/zlib/zlib-${zlib_version}.tar.gz"
 tar -xzvf "zlib-${zlib_version}.tar.gz"
 
 echo "-----> Downloading NGINX ${nginx_version}"
@@ -64,12 +74,12 @@ tar czf "$tempdir/nginx-${nginx_version}.tgz" *
 
 popd
 
-echo "-----> Uploading package to s3://$S3_BUCKET/package/nginx-${nginx_version}.tgz"
+echo "-----> Uploading package to s3://$S3_BUCKET/develop/$TARGET_STACK/package/nginx-${nginx_version}.tgz"
 
 s3cmd put --verbose \
     --acl-public \
     "$tempdir/nginx-${nginx_version}.tgz" \
-    "s3://$S3_BUCKET/package/nginx-${nginx_version}.tgz"
+    "s3://$S3_BUCKET/develop/$TARGET_STACK/package/nginx-${nginx_version}.tgz"
 
 "$basedir/manifest" nginx
 "$basedir/package-checksum" "nginx-${nginx_version}"

--- a/support/package_nginx
+++ b/support/package_nginx
@@ -44,6 +44,8 @@ rm -rf $tempdir
 mkdir -p $tempdir
 cd $tempdir
 
+rm -rf /app/vendor/nginx
+
 echo "-----> Downloading dependency PCRE ${pcre_version}"
 
 curl -LO "http://sourceforge.net/projects/pcre/files/pcre/${pcre_version}/pcre-${pcre_version}.tar.gz"

--- a/support/package_php
+++ b/support/package_php
@@ -8,6 +8,16 @@ source "$basedir/../conf/buildpack.conf"
 
 export PATH=${basedir}/../vendor/bin:$PATH
 
+if [ -z "$S3_BUCKET" ]; then
+    echo "Must set S3_BUCKET environment variable" >&2
+    exit 1
+fi
+
+if [ -z "$TARGET_STACK" ]; then
+    echo "TARGET_STACK must be set" >&2
+    exit 1
+fi
+
 if [ -z "$1" ]; then
     echo "Usage: $0 <version>" >&2
     exit 1
@@ -29,7 +39,7 @@ cd $tempdir
 
 echo "-----> Downloading dependency zlib ${zlib_version}"
 
-curl -LO "http://$S3_BUCKET.s3.amazonaws.com/zlib/zlib-${PHP_ZLIB_VERSION}.tar.gz"
+curl -LO "https://$S3_BUCKET.s3.amazonaws.com/zlib/zlib-${PHP_ZLIB_VERSION}.tar.gz"
 tar -xzvf "zlib-${PHP_ZLIB_VERSION}.tar.gz"
 
 echo "-----> Downloading PHP $php_version"
@@ -39,8 +49,8 @@ tar -xzvf "php-${php_version}.tar.gz"
 echo "-----> Downloading dependencies (libmcrypt, libicu)"
 
 mkdir -p "/app/vendor/php/zlib" "/app/vendor/libmcrypt" "/app/vendor/libicu"
-curl "http://${S3_BUCKET}.s3.amazonaws.com/package/libicu-51.tgz" | tar xzv -C /app/vendor/libicu
-curl "http://${S3_BUCKET}.s3.amazonaws.com/package/libmcrypt-${mcrypt_version}.tgz" | tar xzv -C /app/vendor/libmcrypt
+curl "https://${S3_BUCKET}.s3.amazonaws.com/develop/$TARGET_STACK/package/libicu-51.tgz" | tar xzv -C /app/vendor/libicu
+curl "https://${S3_BUCKET}.s3.amazonaws.com/develop/$TARGET_STACK/package/libmcrypt-${mcrypt_version}.tgz" | tar xzv -C /app/vendor/libmcrypt
 export LD_LIBRARY_PATH=/app/vendor/libicu/lib
 export PATH="/app/vendor/libicu/bin:$PATH"
 
@@ -117,7 +127,7 @@ echo "-----> Moving package to S3"
 s3cmd put \
     --verbose --acl-public \
     "$tempdir/php-${php_version}.tgz" \
-    "s3://$S3_BUCKET/package/php-${php_version}.tgz"
+    "s3://$S3_BUCKET/develop/$TARGET_STACK/package/php-${php_version}.tgz"
 
 "$basedir/manifest" php
 "$basedir/package-checksum" "php-${php_version}"

--- a/support/package_php
+++ b/support/package_php
@@ -37,6 +37,8 @@ rm -rf $tempdir
 mkdir -p $tempdir
 cd $tempdir
 
+rm -rf /app/vendor/php
+
 echo "-----> Downloading dependency zlib ${zlib_version}"
 
 curl -LO "https://$S3_BUCKET.s3.amazonaws.com/zlib/zlib-${PHP_ZLIB_VERSION}.tar.gz"


### PR DESCRIPTION
The cedar stack is deprecated. This adds support for the cedar-14 stack too.
The list of available versions is different on cedar and cedar-14 (PHP 5.3 and 5.4 are not compiled for cedar-14 as they are EOLed, and cedar will not receive new versions anymore as it will disappear in a few weeks).

I also separated the compiled assets for the master and the development branches, allowing to try new versions of extensions in development first (as extension themselves are not versionned in the S3)

This also fix the compilation scripts to be able to run multiple compilation in the same dyno instead of having to launch a new one each time, by cleaning the necessary directories.
