### PR TITLE
Update the pecl channel when building PHP

### DIFF
--- a/support/package_php
+++ b/support/package_php
@@ -93,7 +93,10 @@ cd php-${php_version}
     --disable-debug
 make
 make install
+
+echo "-----> Preparing PECL and PEAR..."
 /app/vendor/php/bin/pear config-set php_dir /app/vendor/php
+/app/vendor/php/bin/pecl channel-update pecl.php.net
 
 echo "-----> Installing OPCache"
 


### PR DESCRIPTION
This avoids a warning when running pecl saying that the protocol was updated.

Note that this has been applied when compiling PHP for cedar-14 in #177 
